### PR TITLE
Add nested condition support

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,37 +1,48 @@
 import * as process from 'process'
 import * as cp from 'child_process'
 import * as path from 'path'
+import ProcessEnv = NodeJS.ProcessEnv;
+
+const executeActionWithEnv = ({ env }: { env: ProcessEnv }) => {
+  const ip = path.join(__dirname, '..', 'lib', 'main.js')
+  const options: cp.ExecSyncOptions = { env }
+
+  return cp.execSync(`node ${ip}`, options).toString().trim()
+}
+const getExpectedActionOutput = ({ expectedValue }: { expectedValue: string }): string => {
+  return `::set-output name=value::${expectedValue}`
+}
 
 // shows how the runner will run a javascript action with env / stdout protocol
 test('test runs (true)', () => {
+  expect.assertions(1)
+
   process.env['INPUT_COND'] = 'true'
   process.env['INPUT_IF_TRUE'] = 'value-if-true'
   process.env['INPUT_IF_FALSE'] = 'value-if-false'
-  const ip = path.join(__dirname, '..', 'lib', 'main.js')
-  const options: cp.ExecSyncOptions = {
-    env: process.env
-  }
-  console.log(cp.execSync(`node ${ip}`, options).toString())
+
+  expect(executeActionWithEnv({ env: process.env }))
+      .toBe(getExpectedActionOutput({ expectedValue: 'value-if-true' }));
 })
 
 test('test runs (false)', () => {
+  expect.assertions(1)
+
   process.env['INPUT_COND'] = 'false'
   process.env['INPUT_IF_TRUE'] = 'value-if-true'
   process.env['INPUT_IF_FALSE'] = 'value-if-false'
-  const ip = path.join(__dirname, '..', 'lib', 'main.js')
-  const options: cp.ExecSyncOptions = {
-    env: process.env
-  }
-  console.log(cp.execSync(`node ${ip}`, options).toString())
+
+  expect(executeActionWithEnv({ env: process.env }))
+      .toBe(getExpectedActionOutput({ expectedValue: 'value-if-false' }));
 })
 
 test('test runs (empty)', () => {
+  expect.assertions(1)
+
   process.env['INPUT_COND'] = 'true'
   process.env['INPUT_IF_TRUE'] = ''
   process.env['INPUT_IF_FALSE'] = 'value-if-false'
-  const ip = path.join(__dirname, '..', 'lib', 'main.js')
-  const options: cp.ExecSyncOptions = {
-    env: process.env
-  }
-  console.log(cp.execSync(`node ${ip}`, options).toString())
+
+  expect(executeActionWithEnv({ env: process.env }))
+      .toBe(getExpectedActionOutput({ expectedValue: '' }));
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,28 @@
 import * as core from '@actions/core'
 
+function evaluateCondition({ cond, ifTrue, ifFalse }:
+  { cond: string, ifTrue: string|Object, ifFalse: string|Object }): string {
+  const evaluatedIfTrue: string = typeof ifTrue === Object ? evaluateCondition({
+    cond: ifTrue.cond,
+    ifTrue: ifTrue.ifTrue,
+    ifFalse: ifTrue.ifFalse,
+  }) : ifTrue
+
+  const evaluatedIfFalse: string = typeof ifFalse === Object ? evaluateCondition({
+    cond: ifFalse.cond,
+    ifTrue: ifFalse.ifTrue,
+    ifFalse: ifFalse.ifFalse,
+  }) : ifFalse
+  
+  return cond === 'true' ? evaluatedIfTrue : evaluatedIfFalse
+}
+
 async function run(): Promise<void> {
   try {
-    const cond: string = core.getInput('cond', {required: true})
-    const ifTrue: string = core.getInput('if_true')
-    const ifFalse: string = core.getInput('if_false')
-    core.setOutput('value', cond === 'true' ? ifTrue : ifFalse)
+    const cond: string = core.getInput('cond', { required: true })
+    const ifTrue: string|Object = core.getInput('if_true')
+    const ifFalse: string|Object = core.getInput('if_false')
+    core.setOutput('value', evaluateCondition({ cond, ifTrue, ifFalse }))
   } catch (error) {
     if (error instanceof Error) {
       core.setFailed(error.message)


### PR DESCRIPTION
This PR adds nested condition support, such that the `if_true` and `if_false` can also contain conditions in themselves. Also tests are refactored to make them actually fail on the process outputting a non-expected value.